### PR TITLE
Fixed issue with player falling through colliders

### DIFF
--- a/Assets/Scenes/SampleScene.unity
+++ b/Assets/Scenes/SampleScene.unity
@@ -3402,8 +3402,8 @@ Rigidbody2D:
   m_GravityScale: 10
   m_Material: {fileID: 0}
   m_Interpolate: 0
-  m_SleepingMode: 1
-  m_CollisionDetection: 0
+  m_SleepingMode: 0
+  m_CollisionDetection: 1
   m_Constraints: 4
 --- !u!61 &1693582701
 BoxCollider2D:


### PR DESCRIPTION
The problem was that the rigidbody sleeping mode was set to discrete and the collision detection was set to discrete, this causes issues with fast-moving objects on small colliders like tiles/edge colliders/others.